### PR TITLE
feat : 상단고정, isNew, isPinned 업데이트 API 추가

### DIFF
--- a/src/main/java/com/soi/backend/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/soi/backend/domain/category/controller/CategoryController.java
@@ -6,6 +6,7 @@ import com.soi.backend.domain.category.dto.CategoryInviteResponseReqDto;
 import com.soi.backend.domain.category.dto.CategoryRespDto;
 import com.soi.backend.domain.category.entity.CategoryFilter;
 import com.soi.backend.domain.category.service.CategoryService;
+import com.soi.backend.domain.post.dto.PostRespDto;
 import com.soi.backend.global.ApiResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -54,6 +55,13 @@ public class CategoryController {
                                                                                @RequestParam Long userId) {
         List<CategoryRespDto> categories = categoryService.findCategories(categoryFilter, userId);
         return ResponseEntity.ok(ApiResponseDto.success(categories, "카테고리 조회 완료"));
+    }
 
+    @Operation(summary = "카테고리 고정", description = "카테고리 아이디, 유저 아이디로 카테고리를 고정 혹은 고정해제 시킵니다.")
+    @PostMapping("/category-pinned")
+    public ResponseEntity<ApiResponseDto<Boolean>> categoryPinned(@RequestParam Long categoryId,
+                                                                  @RequestParam Long userId) {
+        Boolean result = categoryService.setPinned(categoryId, userId);
+        return ResponseEntity.ok(ApiResponseDto.success(result,"상단고정값 변경 완료"));
     }
 }

--- a/src/main/java/com/soi/backend/domain/category/dto/CategoryRespDto.java
+++ b/src/main/java/com/soi/backend/domain/category/dto/CategoryRespDto.java
@@ -18,14 +18,16 @@ public class CategoryRespDto {
 
     private Boolean isPinned;
     private List<String> usersProfile; // 카테고리에 있는 유저들 프로필 사진
+    private LocalDateTime pinnedAt;
 
-    public CategoryRespDto(Category category, CategoryUser categoryUser, List<String> usersProfile, String categoryPhotoUrl) {
+    public CategoryRespDto(Category category, CategoryUser categoryUser, List<String> usersProfile, String categoryPhotoUrl,  LocalDateTime pinnedAt) {
         this.id = category.getId();
         this.name = categoryUser.getCustomName().isEmpty() ? category.getName() : categoryUser.getCustomName();
         this.categoryPhotoUrl = categoryPhotoUrl;
         this.isNew = isNew(category.getLastPhotoUploadedAt(), categoryUser.getLastViewedAt());
         this.isPinned = categoryUser.getIsPinned();
         this.usersProfile = usersProfile;
+        this.pinnedAt = pinnedAt;
     }
 
     private boolean isNew(LocalDateTime uploadedAt, LocalDateTime viewedAt) {

--- a/src/main/java/com/soi/backend/domain/category/entity/CategoryUser.java
+++ b/src/main/java/com/soi/backend/domain/category/entity/CategoryUser.java
@@ -39,6 +39,9 @@ public class CategoryUser {
     @Column(name = "last_viewed_at")
     private LocalDateTime lastViewedAt;
 
+    @Column(name = "pinned_at")
+    private LocalDateTime pinnedAt;
+
     public CategoryUser(Long categoryId, Long inviterUserId) {
         this.categoryId = categoryId;
         this.userId = inviterUserId;
@@ -47,5 +50,14 @@ public class CategoryUser {
         this.isPinned = false;
         this.isRead = false;
         this.lastViewedAt = null;
+    }
+
+    public void setLastViewedAt() {
+        this.lastViewedAt = LocalDateTime.now();
+    }
+
+    public void setIsPinned() {
+        isPinned = !isPinned;
+        this.pinnedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/soi/backend/domain/post/controller/PostController.java
+++ b/src/main/java/com/soi/backend/domain/post/controller/PostController.java
@@ -44,10 +44,11 @@ public class PostController {
         return ResponseEntity.ok(ApiResponseDto.success(null,"게시물 임시삭제 완료"));
     }
 
-    @Operation(summary = "카테고리에 해당하는 게시물 조회", description = "카테고리 아이디로 해당 카테고리에 속한 게시물을 조회합니다.")
+    @Operation(summary = "카테고리에 해당하는 게시물 조회", description = "카테고리 아이디, 유저아이디로 해당 카테고리에 속한 게시물을 조회합니다.")
     @GetMapping("/find-by/category")
-    public ResponseEntity<ApiResponseDto<List<PostRespDto>>> findByCategoryId(@RequestParam Long categoryId) {
-        List<PostRespDto> postRespDtos = postService.findByCategoryId(categoryId);
+    public ResponseEntity<ApiResponseDto<List<PostRespDto>>> findByCategoryId(@RequestParam Long categoryId,
+                                                                              @RequestParam Long userId) {
+        List<PostRespDto> postRespDtos = postService.findByCategoryId(categoryId, userId);
         return ResponseEntity.ok(ApiResponseDto.success(postRespDtos,"게시물 조회 완료"));
     }
 


### PR DESCRIPTION
사용자가 카테고리의 게시물을 조회하면 해당 카테고리의 isNew를 false로 수정
누군가가 카테고리에 포스팅을 하면 카테고리의 lastUpdatedAt, lastPhotoUploaed를 최신화 상단고정 요청 API 생성 (리턴값 : 바뀐 Pinned 상태)
카테고리 게시물 조회 요청하면, Pinned와 상단고정한 일자를 기준으로 최신이 앞에 오도록 정렬해서 보내도록 변경